### PR TITLE
ajout du deuxieme crawler dans FetchProductsJob

### DIFF
--- a/app/Jobs/FetchProductsJob.php
+++ b/app/Jobs/FetchProductsJob.php
@@ -2,7 +2,8 @@
 
 namespace App\Jobs;
 
-use App\Http\Controllers\Api\SaqController;
+use App\Http\Controllers\Api\SaqCatalogueController;
+use App\Http\Controllers\Api\SaqProductController;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -20,10 +21,13 @@ class FetchProductsJob implements ShouldQueue
 
     public function handle()
     {
-        $saqController = new SaqController();
+        $SaqCatalogueController = new SaqCatalogueController();
         $totalPages = 342; 
         for ($i = 1; $i <= $totalPages; $i++) {
-            $saqController->getProduits(24,$i);
+            $SaqCatalogueController->getProduits(24,$i);
         }
+
+        $SaqProductController = new SaqProductController();
+        $SaqProductController->getItem();
     }
 }


### PR DESCRIPTION
Les deux Crawler sont maitenant déclancher automatiquement deux soir par semaine.

les Mercredi et dimanche 3h30.

Fonctionne simplement de cette facon pour l'instant.
Reste a optimisé et ajuster pour le pannel admin
v1.001